### PR TITLE
Force js-ipfs 0.32.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "delta-crdts": "^0.3.0",
     "frequency-counter": "^1.0.1",
     "interface-datastore": "~0.4.2",
-    "ipfs": "^0.32.0-rc.2",
+    "ipfs": "0.32.2",
     "ipfs-api": "^22.2.4",
     "leftpad": "0.0.1",
     "libp2p": "^0.23.1",


### PR DESCRIPTION
Version 0.32.3 of js-ipfs has regressions:

https://travis-ci.org/ipfs-shipyard/peer-star-app/builds/435707042

Forcing 0.32.2 will get the tests passing again:

https://travis-ci.org/jimpick/peer-star-app/builds/437465067

We should investigate the regressions, of course, but I will be submitting some other pull requests, and it would be nice for them to pass on Travis.