### PR TITLE
Set outbound peers in observer from outbound connections

### DIFF
--- a/src/collaboration/connection-manager.js
+++ b/src/collaboration/connection-manager.js
@@ -79,7 +79,7 @@ module.exports = class ConnectionManager extends EventEmitter {
   observe (observer) {
     const onConnectionChange = () => {
       observer.setInboundPeers(peerIdSetFromPeerSet(this._inboundConnections))
-      observer.setOutboundPeers(peerIdSetFromPeerSet(this._inboundConnections))
+      observer.setOutboundPeers(peerIdSetFromPeerSet(this._outboundConnections))
     }
 
     this._protocol.on('inbound connection', onConnectionChange)


### PR DESCRIPTION
Right now, it's using inbound connections to set outbound peers.