### PR TITLE
Use peerId with _peerCollaborations.get() in Global Connection Manager

### DIFF
--- a/src/transport/global-connection-manager.js
+++ b/src/transport/global-connection-manager.js
@@ -123,7 +123,8 @@ module.exports = class GlobalConnectionManager {
       return
     }
 
-    const dialedProtocols = this._peerCollaborations.get(peerInfo)
+    const peerId = peerInfo.id.toB58String()
+    const dialedProtocols = this._peerCollaborations.get(peerId)
     const canClose = !dialedProtocols || !dialedProtocols.size
     if (canClose) {
       debug('hanging up %s', peerInfo.id.toB58String())


### PR DESCRIPTION
The map isn't indexed with peerInfo