### PR TITLE
Fix ring .remove() bug due to string/integer types

### DIFF
--- a/src/common/ring.js
+++ b/src/common/ring.js
@@ -35,7 +35,8 @@ class Ring extends EventEmitter {
       if (comparison === 0) {
         // found point
         const points = this._points
-        this._points = points.slice(0, i).concat(points.slice(i + 1))
+        const index = parseInt(i, 10)
+        this._points = points.slice(0, index).concat(points.slice(index + 1))
         this._contacts.delete(p.toString('hex'))
         this.emit('removed', peerInfo)
         this.emit('changed')


### PR DESCRIPTION
Because the `i` variable from the for..in loop is a string, the `i + 1` code would be too large and would end up removing most of the points.