### PR TITLE
Fix delta trimming

### DIFF
--- a/src/collaboration/store.js
+++ b/src/collaboration/store.js
@@ -337,7 +337,7 @@ module.exports = class CollaborationStore extends EventEmitter {
         }),
         pull.map((d) => d.key),
         pull.asyncMap((key, callback) => {
-          const thisSeq = Number(key.toString().substring(3))
+          const thisSeq = parseInt(key.toString().slice(-3), 16)
           if (thisSeq < first) {
             debug('%s: trimming delta with sequence %s', this._id, thisSeq)
             this._store.delete(key, callback)


### PR DESCRIPTION
I think perhaps the name convention for the keys changed?

This fix only looks at the last 3 hex characters of the key ...
that might not be correct.