### PR TITLE
Fix collaboration protocol test

### DIFF
--- a/test/collaboration-protocol.spec.js
+++ b/test/collaboration-protocol.spec.js
@@ -16,7 +16,8 @@ const Protocol = require('../src/collaboration/protocol')
 const Clocks = require('../src/collaboration/clocks')
 const generateKeys = require('../src/keys/generate')
 
-const Type = require('./utils/fake-crdt')
+require('./utils/fake-crdt')
+const Type = require('../src/collaboration/crdt')('fake')
 
 const _storeOptions = {
   maxDeltaRetention: 0,


### PR DESCRIPTION
Without this fix, running
`./node_modules/.bin/aegir test -t node -f test/collaboration-protocol.spec.js`

Causes
`Error: undefined is not encodable in msgpack!`