### PR TITLE
WIP: Implement persistence service

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:node": "aegir test -t node",
     "test:browser": "aegir test -t browser",
     "lint": "standard src/**/*.js",
+    "lint:fix": "standard --fix src/**/*.js",
     "test:perf": "mocha test/performance/all.js",
     "pinner": "node bin/pinner"
   },

--- a/src/collaboration/store.js
+++ b/src/collaboration/store.js
@@ -67,6 +67,11 @@ module.exports = class CollaborationStore extends EventEmitter {
       [this.getLatestClock(), this.getStates()]))
   }
 
+  getClockAndState (name) {
+    return this._queue.add(() => Promise.all(
+      [this.getLatestClock(), this.getState(name)]))
+  }
+
   saveDelta ([previousClock, authorClock, delta]) {
     return this._queue.add(async () => {
       debug('%s: save delta: %j', this._id, [previousClock, authorClock, delta])

--- a/src/common/shared-crypto.js
+++ b/src/common/shared-crypto.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const { encode, decode } = require('delta-crdts-msgpack-codec')
+
+function signAndEncrypt (keys, data) {
+  return new Promise((resolve, reject) => {
+    if (!keys.write) {
+      return resolve(data)
+    }
+    keys.write.sign(data, (err, signature) => {
+      if (err) {
+        return reject(err)
+      }
+
+      const toEncrypt = encode([data, signature])
+
+      keys.cipher()
+        .then((cipher) => {
+          cipher.encrypt(toEncrypt, (err, encrypted) => {
+            if (err) {
+              return reject(err)
+            }
+
+            resolve(encrypted)
+          })
+        })
+        .catch(reject)
+    })
+  })
+}
+
+function decryptAndVerify (keys, encrypted) {
+  return new Promise((resolve, reject) => {
+    if (!keys.cipher && !keys.read) {
+      return resolve(encrypted)
+    }
+    keys.cipher()
+      .then((cipher) => cipher.decrypt(encrypted, (err, decrypted) => {
+        if (err) {
+          return reject(err)
+        }
+        const decoded = decode(decrypted)
+        const [encoded, signature] = decoded
+
+        keys.read.verify(encoded, signature, (err, valid) => {
+          if (err) {
+            return reject(err)
+          }
+
+          if (!valid) {
+            return reject(new Error('delta has invalid signature'))
+          }
+
+          resolve(encoded)
+        })
+      }))
+      .catch(reject)
+  })
+}
+
+module.exports = {
+  signAndEncrypt,
+  decryptAndVerify
+}

--- a/src/persister/index.js
+++ b/src/persister/index.js
@@ -1,0 +1,302 @@
+'use strict'
+
+const debug = require('debug')('peer-star:persister:collab')
+const dbgq = (...args) => debug('Process queue: ' + args.shift(), ...args)
+const EventEmitter = require('events')
+const Queue = require('p-queue')
+const vectorclock = require('../common/vectorclock')
+const Naming = require('./naming')
+const OpQueue = require('./op-queue')
+const Persistence = require('./persistence')
+const PersistenceHeuristic = require('./persistence-heuristic')
+const { encode, decode } = require('delta-crdts-msgpack-codec')
+
+const defaultOptions = {
+  // How long to wait before retrying if there's an error
+  retryInterval: 10000
+}
+
+class CollaborationPersister extends EventEmitter {
+  constructor (ipfs, name, type, store, options) {
+    super()
+    this._name = name
+    this._type = type
+    this._store = store
+    this._options = Object.assign({}, defaultOptions, options)
+
+    // Queue of operations
+    this._opQueue = new OpQueue()
+    // Queue for processing operations
+    this._processQueue = new Queue({ concurrency: 1 })
+
+    // Number of deltas that have been added on top of the last snapshot
+    this._branchDeltaCount = 0
+
+    this._onDelta = this._onDelta.bind(this)
+    this._onSnapshot = this._onSnapshot.bind(this)
+
+    this._naming = this._options.naming || new Naming(name, ipfs, this._options)
+    this._publishQueue = new Queue({ concurrency: 1 })
+
+    this._persistence = this._options.persistence || new Persistence(ipfs, this._options)
+    this._persistenceHeuristic = this._options.persistenceHeuristic || new PersistenceHeuristic(this, this._options.persistenceHeuristicOptions)
+    this._persistenceHeuristic.on('snapshot', this._onSnapshot)
+  }
+
+  // Get the last saved state from persistence
+  // This should be called and the snapshot joined
+  // with current state before starting the persister
+  async fetchLatestState () {
+    await this._startPersistenceAndNaming()
+
+    let cid = await this._naming.fetch()
+    if (!cid) return undefined
+
+    // commit: {
+    //   parentCid: <cid>,
+    //   clock: <clock>,
+    //   record: encode([
+    //     'collab name',
+    //     'crdt type',
+    //     encrypt(encode(<state>))
+    //   ])
+    // }
+
+    let commit
+    const deltaClocks = []
+    while (cid) {
+      commit = await this._persistence.fetch(cid)
+      // debug('cid', cid.toBaseEncodedString(), 'commit:', commit)
+      const { parent, clock, record: encodedRec } = commit
+      const isBuffer = encodedRec instanceof Buffer
+      if (isBuffer) {
+        const rec = decode(encodedRec)
+        const encryptedState = rec[2]
+        // debug('rec', rec)
+        const encodedState = await this._options.decryptAndVerify(encryptedState)
+        const state = decode(encodedState)
+        // debug('plaintext', [name, type, state])
+        deltaClocks.unshift({ clock, state })
+      }
+      cid = parent
+    }
+
+    // debug('all delta clocks', deltaClocks)
+    const deltas = deltaClocks.map(d => d.state)
+    const joined = joinDeltas(this._type, deltas)
+    // debug('joined deltas', joined)
+
+    const clocks = deltaClocks.map(d => d.clock)
+    const merged = clocks.reduce((C, c) => vectorclock.merge(C, c), {})
+    // debug('joined clocks', merged)
+
+    const encryptedState = await this._options.signAndEncrypt(encode(joined))
+    const rec = [this._name, this._type.typeName, encryptedState]
+    return { clock: merged, state: encode(rec) }
+  }
+
+  // waitForPublish indicates whether to wait for the snapshot that is created
+  // on startup to be published to the naming service
+  start (waitForPublish) {
+    if (!this._starting) {
+      this._starting = this._start(waitForPublish)
+    }
+    return this._starting
+  }
+
+  async _start (waitForPublish) {
+    await this._startPersistenceAndNaming()
+
+    // First we want to save a snapshot
+    this._opQueue.pushHeadSnapshot()
+
+    // Start listening for snapshot events and deltas
+    this._persistenceHeuristic.start()
+    this._store.on('delta', this._onDelta)
+
+    // Wait for the first snapshot to be persisted
+    await Promise.all([
+      this._triggerProcessQueue(),
+      // If the caller wants to we wait until the snapshot has actually
+      // been published before returning
+      waitForPublish && new Promise(resolve => this.once('publish', resolve))
+    ])
+  }
+
+  _startPersistenceAndNaming () {
+    if (this._persistenceAndNamingStarting) return
+
+    this._persistenceAndNamingStarting = true
+    return Promise.all([
+      this._persistence.start(),
+      this._naming.start()
+    ])
+  }
+
+  async stop () {
+    this._store.removeListener('delta', this._onDelta)
+    this._persistenceHeuristic.stop()
+    this._publishQueue.clear()
+    this._processQueue.clear()
+    await Promise.all([
+      this._publishQueue.onIdle(),
+      this._processQueue.onIdle()
+    ])
+    await Promise.all([
+      this._persistence.stop(),
+      this._naming.stop()
+    ])
+  }
+
+  _onDelta (delta, clock) {
+    debug('Delta received')
+    this._opQueue.pushTailDelta(clock, delta)
+    debug('New op queue:', this._opQueue.ops())
+    this._triggerProcessQueue()
+  }
+
+  _onSnapshot () {
+    debug('Snapshot requested')
+
+    // A snapshot event has been fired.
+    const front = this._opQueue.peekHead()
+
+    // If the operations queue already has a snapshot at the front of it, then
+    // we don't need to do anything.
+    if (front && front.type === 'SNAPSHOT') {
+      debug('Ignoring request - already have snapshot at op queue head')
+      return
+    }
+
+    // If the operations queue has a delta at the front of it, the delta is
+    // already being processed. We want to make sure that the delta is also
+    // included in this new snapshot, so duplicate the delta, then add the
+    // snapshot to the front of the operations queue.
+    if (front && front.type === 'DELTA') {
+      debug('Duplicating delta at op queue head')
+      this._opQueue.dupHead()
+    }
+    this._opQueue.pushHeadSnapshot()
+    debug('New op queue', this._opQueue.ops())
+    this._triggerProcessQueue()
+  }
+
+  _triggerProcessQueue () {
+    return this._processQueue.add(() => this._processOpQueue())
+  }
+
+  async _processOpQueue () {
+    dbgq('Queue(%d):', this._opQueue.length(), this._opQueue.ops())
+
+    // There are no operations in the queue
+    const op = this._opQueue.peekHead()
+    if (!op) {
+      dbgq('Done - No operations in queue')
+      return
+    }
+
+    dbgq('Processing %s', op.type)
+
+    try {
+      if (op.type === 'SNAPSHOT') {
+        await this._processSnapshot()
+        this._opQueue.remove(op.id)
+        this._triggerProcessQueue()
+        return
+      }
+
+      const processed = await this._processDelta(op.data)
+      if (processed) {
+        this._opQueue.remove(op.id)
+        this._triggerProcessQueue()
+      }
+    } catch (e) {
+      this.emit('error', e)
+      dbgq('Caught error', e)
+      setTimeout(() => this._triggerProcessQueue(), this._options.retryInterval)
+    }
+  }
+
+  async _processDelta (delta) {
+    // We don't have a snapshot to append to yet
+    if (!this._lastSnapshot) {
+      dbgq('Done - No snapshot: delta processing blocked')
+      return false
+    }
+
+    // The delta is already contained by the last snapshot
+    if (vectorclock.doesSecondHaveFirst(delta.clock, this._lastSnapshot.clock)) {
+      dbgq('Done - delta clock %j already contained by latest snapshot %j',
+        delta.clock, this._lastSnapshot.clock)
+      return true
+    }
+
+    // Commit the delta to persistent storage
+    const cid = await this._persistence.save(this._parentCid, delta.clock, delta.delta)
+    dbgq('Done - Saved delta with clock %j to persistent storage. CID: %j Parent: %j',
+      delta.clock, cid.toBaseEncodedString(), this._parentCid.toBaseEncodedString())
+
+    this._parentCid = cid
+    this._branchDeltaCount++
+    this.emit('branch delta count', this._branchDeltaCount, cid)
+
+    // Update the name to point to the new HEAD state
+    // (note that we don't wait for this to finish)
+    this._enqueueHeadUpdate(cid)
+    return true
+  }
+
+  async _processSnapshot () {
+    // Get the latest snapshot from the store
+    let [clock, state] = await this._store.getClockAndState(this._name)
+
+    // If the store state is the same as the latest snapshot, no need to save it
+    dbgq('Comparing latest clock from store %j to last snapshot clock %j', clock, (this._lastSnapshot || {}).clock)
+    if (this._lastSnapshot && vectorclock.isIdentical(this._lastSnapshot.clock, clock)) {
+      dbgq('Done - Clocks are identical')
+      return
+    }
+
+    // Save the snapshot
+    state = state || null
+    this._parentCid = await this._persistence.save(null, clock, state)
+    dbgq('Done - Saved snapshot %j to persistence. CID:', clock, this._parentCid.toBaseEncodedString())
+
+    // Update the name to point to the new HEAD state
+    // (note that we don't wait for this to finish)
+    this._enqueueHeadUpdate(this._parentCid)
+
+    // Save a copy of the snapshot and reset the count of deltas on top of
+    // the snapshot
+    this._lastSnapshot = { clock, state }
+    this._branchDeltaCount = 0
+  }
+
+  _enqueueHeadUpdate (cid) {
+    // We only want to save the latest HEAD so clear any previous publish
+    // events in the queue
+    this._publishQueue.clear()
+    return this._publishQueue.add(async () => {
+      await this._naming.update(cid)
+      debug('Updated HEAD to CID: %s', cid.toBaseEncodedString())
+      this.emit('publish', cid)
+    })
+  }
+}
+
+// TODO: shared code
+class VoidChangeEmitter {
+  changed (event) {}
+  emitAll () {}
+}
+
+const voidChangeEmitter = new VoidChangeEmitter()
+function joinDeltas (crdtType, deltas) {
+  return deltas.reduce(
+    (D, d) => crdtType.join.call(voidChangeEmitter, D, d),
+    crdtType.initial())
+}
+
+module.exports = (ipfs, collabName, type, store, options) => {
+  return new CollaborationPersister(ipfs, collabName, type, store, options)
+}

--- a/src/persister/naming.js
+++ b/src/persister/naming.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const CID = require('cids')
+
+const debug = require('debug')('peer-star:persister:naming')
+
+const defaultOptions = {}
+
+module.exports = class Naming {
+  constructor (collabName, ipfs, options) {
+    this.collabName = collabName
+    this._ipfs = ipfs
+    this._options = Object.assign({}, defaultOptions, options)
+    if (!this._options.ipfs.pass) throw new Error('A key passphrase must be supplied for IPNS')
+    if (!this._options.ipns) throw new Error('An IPNS config must be supplied')
+    if (!this._options.ipns.key) throw new Error('A key must be supplied for IPNS')
+    // Note: ECDSA keys don't seem to have an export function
+    if (!this._options.ipns.key.export) throw new Error('A key that has an export() function must be supplied for IPNS')
+  }
+
+  async start () {
+    await new Promise(resolve => {
+      this._ipfs.isOnline() ? resolve() : this._ipfs.once('ready', resolve)
+    })
+
+    // Check if the key has been imported
+    const keys = await this._ipfs.key.list()
+    const keyName = this._getKeyName()
+    this._key = keys.find(k => k.name === keyName)
+    if (this._key) {
+      debug('Key has been imported already:', this._key)
+      return
+    }
+
+    // No key found, we need to export out key to pem and then import it into
+    // ipfs
+    debug('Key %s not found, generating pem for import', keyName)
+    const pem = await new Promise((resolve, reject) => {
+      this._options.ipns.key.export(this._options.ipfs.pass, (err, pem) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve(pem)
+      })
+    })
+    debug('Importing pem for key %s', keyName)
+    this._key = await this._ipfs.key.import(keyName, pem, this._options.ipfs.pass)
+    debug('Import complete:', this._key)
+  }
+
+  stop () {
+    // Note: IPFS should be stopped by the process that passed it to this class
+  }
+
+  _getKeyName () {
+    return 'peer-star-app.naming.' + this.collabName
+  }
+
+  async fetch () {
+    try {
+      const res = await this._ipfs.name.resolve(this._key.id)
+      if ((res || {}).path) {
+        debug('Fetched HEAD: %s', res.path)
+        return new CID(res.path.replace('/ipfs/', ''))
+      }
+      return undefined
+    } catch (e) {
+      if (e.code === 'ERR_NO_LOCAL_RECORD_FOUND') {
+        return undefined
+      }
+      throw e
+    }
+  }
+
+  async update (cid) {
+    debug('Updating HEAD to %s', cid.toBaseEncodedString())
+    await this._ipfs.name.publish(cid, {
+      resolve: false,
+      key: this._getKeyName()
+    })
+    debug('Done - Updated HEAD to %s', cid.toBaseEncodedString())
+  }
+}

--- a/src/persister/op-queue.js
+++ b/src/persister/op-queue.js
@@ -1,0 +1,58 @@
+'use strict'
+
+// Maintains a queue of DELTA and SNAPSHOT operations
+class OpQueue {
+  constructor () {
+    this.counter = 0
+    this.queue = []
+  }
+
+  length () {
+    return this.queue.length
+  }
+
+  // Printable array of "id: type"
+  ops () {
+    return this.queue.map(i => i.id + ': ' + i.type)
+  }
+
+  pushTailDelta (clock, delta) {
+    this.queue.push({
+      type: 'DELTA',
+      id: this.counter++,
+      data: { clock, delta }
+    })
+  }
+
+  pushHeadSnapshot () {
+    this.queue.unshift({
+      type: 'SNAPSHOT',
+      id: this.counter++
+    })
+  }
+
+  peekHead () {
+    return this.queue[0]
+  }
+
+  dupHead () {
+    const head = this.peekHead()
+    if (head) {
+      const dup = {
+        type: head.type,
+        id: this.counter++, // Note: don't dup ID
+        data: head.data
+      }
+      this.queue.unshift(dup)
+    }
+  }
+
+  remove (id) {
+    const index = this.queue.findIndex(i => i.id === id)
+    if (index >= 0) {
+      this.queue.splice(index, 1)
+    }
+  }
+}
+
+module.exports = OpQueue

--- a/src/persister/persistence-heuristic.js
+++ b/src/persister/persistence-heuristic.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const debug = require('debug')('peer-star:persister:heuristic')
+const EventEmitter = require('events')
+
+const defaultOptions = {
+  samplingIntervalMS: 1000,
+  maxDeltas: 100,
+  maxSnapshotIntervalMS: 5 * 60 * 1000
+}
+
+// TODO: Share code with membership-gossip-frequency-heuristic
+module.exports = class PersistenceHeuristic extends EventEmitter {
+  constructor (deltaCountEmitter, options) {
+    super()
+
+    this._options = Object.assign({}, defaultOptions, options)
+    this._deltaCountEmitter = deltaCountEmitter
+
+    this._onDeltaCountChange = this._onDeltaCountChange.bind(this)
+    this._sample = this._sample.bind(this)
+  }
+
+  start () {
+    debug('Starting heuristic')
+    this._deltaCountEmitter.on('branch delta count', this._onDeltaCountChange)
+    this._lastFired = Date.now()
+    this._samplingInterval = setInterval(this._sample.bind(this), this._options.samplingIntervalMS)
+  }
+
+  stop () {
+    this._deltaCountEmitter.removeListener('branch delta count', this._onDeltaCountChange)
+    clearInterval(this._samplingInterval)
+    this._samplingInterval = null
+    debug('Stopped heuristic')
+  }
+
+  _onDeltaCountChange (count) {
+    debug('branch delta count', count)
+    if (count > this._options.maxDeltas) {
+      debug('Firing snapshot event - branch delta count %d > max deltas %d', count, this._options.maxDeltas)
+      this._fireEvent()
+    }
+  }
+
+  _sample () {
+    const elapsed = Date.now() - this._lastFired
+    if (elapsed > this._options.maxSnapshotIntervalMS) {
+      debug('Firing snapshot event - elapsed time %d > snapshot interval %d', elapsed, this._options.maxSnapshotIntervalMS)
+      this._fireEvent()
+    }
+  }
+
+  _fireEvent () {
+    this._lastFired = Date.now()
+    this.emit('snapshot')
+  }
+}

--- a/src/persister/persistence.js
+++ b/src/persister/persistence.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const CID = require('cids')
+const msgpack = require('delta-crdts-msgpack-codec')
+
+const defaultOptions = {}
+
+module.exports = class Persistence {
+  constructor (ipfs, options) {
+    this._ipfs = ipfs
+    this._options = Object.assign({}, defaultOptions, options)
+    this._codec = this._options.encoder || msgpack
+  }
+
+  start () {
+    return new Promise(resolve => {
+      this._ipfs.isOnline() ? resolve() : this._ipfs.once('ready', resolve)
+    })
+  }
+
+  stop () {
+    // Note: IPFS should be stopped by the process that passed it to this class
+  }
+
+  async fetch (cid) {
+    const dagNode = await this._ipfs.dag.get(cid)
+    const value = dagNode.value
+    const data = this._codec.decode(value.data)
+    return {
+      parent: (value.parent || {})['/'] && new CID(value.parent['/']),
+      clock: data.clock,
+      record: data.record
+    }
+  }
+
+  async save (parentCid, clock, record) {
+    const data = await this._codec.encode({ clock, record })
+    const dagNode = { data }
+    if (parentCid) {
+      dagNode.parent = { '/': parentCid.buffer }
+    }
+    return this._ipfs.dag.put(dagNode)
+  }
+}

--- a/test/persister/memory-impl.js
+++ b/test/persister/memory-impl.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const multihashing = require('multihashing')
+const CID = require('cids')
+
+function simulateDelay (obj, fn, delay) {
+  return function (...args) {
+    return new Promise((resolve, reject) => {
+      try {
+        const res = fn.apply(obj, args)
+        const invocationDelay = Math.random() * delay
+        setTimeout(() => resolve(res), invocationDelay)
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}
+
+class MemoryNaming {
+  constructor (delay = 0) {
+    this.fetch = simulateDelay(this, this.fetch, delay)
+    this.update = simulateDelay(this, this.update, delay)
+    this.objects = {}
+  }
+  start () {}
+  stop () {}
+  fetch () { return this.value }
+  update (value) {
+    this.value = value
+  }
+}
+
+class MemoryPersistence {
+  constructor (delay = 0) {
+    this.fetch = simulateDelay(this, this.fetch, delay)
+    this.save = simulateDelay(this, this.save, delay)
+    this.objects = {}
+  }
+  start () {}
+  stop () {}
+  fetch (cid) {
+    return this.objects[cid.toBaseEncodedString()]
+  }
+  async save (parentCid, clock, record) {
+    const obj = { parent: parentCid, clock, record }
+    const json = JSON.stringify({ parentCid, clock })
+    const cid = new CID(multihashing(Buffer.from(json), 'sha1'))
+    this.objects[cid.toBaseEncodedString()] = obj
+    return cid
+  }
+}
+
+module.exports = {
+  MemoryPersistence,
+  MemoryNaming
+}

--- a/test/persister/persister.spec.js
+++ b/test/persister/persister.spec.js
@@ -1,0 +1,277 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+
+const IPFS = require('ipfs')
+const MemoryDatastore = require('interface-datastore').MemoryDatastore
+const crypto = require('libp2p-crypto')
+const Store = require('../../src/collaboration/store')
+const Shared = require('../../src/collaboration/shared')
+const generateKeys = require('../../src/keys/generate')
+const sharedCrypto = require('../../src/common/shared-crypto')
+const createTempRepo = require('../utils/repo')
+const persister = require('../../src/persister')
+const { MemoryNaming, MemoryPersistence } = require('./memory-impl')
+
+require('../utils/fake-crdt')
+const Type = require('../../src/collaboration/crdt')('fake')
+
+const suiteOptions = {
+  // naming: new MemoryNaming(),
+  // persistence: new MemoryPersistence(),
+}
+
+// Needed for IPNS
+const ipfsOptions = {
+  pass: 'some passphrase goes here'
+}
+
+let createCollab
+describe('persister', function () {
+  this.timeout(10000)
+
+  let keys
+  let collab1, firstPersister, firstIpfs
+  let collab2, secondPersister, secondIpfs
+
+  before(async () => {
+    // We need to use an RSA key to be able to import it for IPNS
+    keys = await generateKeys({
+      algo: 'rsa', bits: 2048
+    })
+    createCollab = (id) => createCollabWithKeys(id, keys)
+  })
+
+  it('creates persister', async () => {
+    firstIpfs = await createIpfs()
+    collab1 = await createCollab('first')
+    const persisterOptions = getPersisterOptions(keys, suiteOptions)
+    firstPersister = persister(firstIpfs, collab1.name, Type, collab1.store, persisterOptions)
+  })
+
+  it('persister latest state is not yet defined', async () => {
+    const state = await firstPersister.fetchLatestState()
+    expect(state).not.to.exist()
+  })
+
+  it('starts persister', async () => {
+    await firstPersister.start(true)
+  })
+
+  it('persister latest state is now the empty state', async () => {
+    const state = await firstPersister.fetchLatestState()
+    expect(state).to.exist()
+    expect(state.clock).to.be.empty()
+    expect(await getStateValue(state.state)).to.equal('')
+  })
+
+  it('mutates state', async () => {
+    await addDeltasAndAwaitPropagation(collab1, firstPersister, ['a', 'b', 'c'])
+  })
+
+  it('persister latest state is now the join of the deltas', async () => {
+    const state = await firstPersister.fetchLatestState()
+    expect(state).to.exist()
+    expect(await getStateValue(state.state)).to.equal('abc')
+  })
+
+  it('mutates state until a snapshot is triggered', async () => {
+    // The persistence heuristic has maxDeltas: 3
+    // We've already added three deltas, so after
+    // adding one more it should trigger a snapshot
+    // to be saved
+    await addDeltasAndAwaitPropagation(collab1, firstPersister, ['d'])
+  })
+
+  it('persister latest state is now just the snapshot', async () => {
+    const state = await firstPersister.fetchLatestState()
+    expect(state).to.exist()
+    expect(await getStateValue(state.state)).to.equal('abcd')
+  })
+
+  it('mutates state to add more deltas', async () => {
+    await addDeltasAndAwaitPropagation(collab1, firstPersister, ['e', 'f'])
+  })
+
+  it('persister latest state is now the snapshot plus new deltas', async () => {
+    const state = await firstPersister.fetchLatestState()
+    expect(state).to.exist()
+    expect(await getStateValue(state.state)).to.equal('abcdef')
+  })
+
+  it('stops first persister', async () => {
+    await firstPersister.stop()
+    await firstIpfs.stop()
+  })
+
+  it('creates second persister', async () => {
+    secondIpfs = await createIpfs()
+    collab2 = await createCollab('second')
+    const persisterOptions = getPersisterOptions(keys, suiteOptions)
+    secondPersister = persister(secondIpfs, collab2.name, Type, collab2.store, persisterOptions)
+  })
+
+  it('adds some local state to second replica', () => {
+    collab2.shared.add('g')
+    collab2.shared.add('h')
+  })
+
+  it('second persister latest state before start is same as first persister state', async () => {
+    const state = await secondPersister.fetchLatestState()
+    expect(state).to.exist()
+    expect(await getStateValue(state.state)).to.equal('abcdef')
+  })
+
+  it('merges second persister latest state with second replicas local state', async () => {
+    const state = await secondPersister.fetchLatestState()
+    await collab2.store.saveDelta([null, state.clock, state.state])
+    expect(collab2.shared.value()).to.equal('abcdefgh')
+  })
+
+  it('starts second persister', async () => {
+    await secondPersister.start(true)
+  })
+
+  it('after startup, second replica local state is reflected in persister', async () => {
+    const state = await secondPersister.fetchLatestState()
+    expect(state).to.exist()
+    expect(await getStateValue(state.state)).to.equal('abcdefgh')
+  })
+
+  it('mutates state', async () => {
+    await addDeltasAndAwaitPropagation(collab2, secondPersister, ['i', 'j'])
+  })
+
+  it('second persister latest state now has new deltas', async () => {
+    const state = await secondPersister.fetchLatestState()
+    expect(state).to.exist()
+    expect(await getStateValue(state.state)).to.equal('abcdefghij')
+  })
+
+  it('stops second persister', async () => {
+    await secondPersister.stop()
+    await secondIpfs.stop()
+  })
+})
+
+async function createCollabWithKeys (id, keys) {
+  const ipfs = {
+    id () {
+      return { id }
+    },
+    _repo: {
+      datastore: new MemoryDatastore()
+    }
+  }
+
+  const collabName = 'persister test'
+  const c = {
+    name: collabName
+  }
+
+  const key = crypto.randomBytes(16)
+  const iv = crypto.randomBytes(16)
+  const storeOptions = {
+    maxDeltaRetention: 0,
+    deltaTrimTimeoutMS: 0,
+    createCipher: () => {
+      return new Promise((resolve, reject) => {
+        crypto.aes.create(Buffer.from(key), Buffer.from(iv), (err, key) => {
+          if (err) {
+            return reject(err)
+          }
+          resolve(key)
+        })
+      })
+    }
+  }
+  const store = new Store(ipfs, c, storeOptions)
+  c.store = store
+  c.store.on('error', err => console.error('Error from %s store', id, err))
+  await store.start()
+
+  const shared = await Shared(c.name, id, Type, c, store, keys)
+  shared.on('error', err => console.error('Error from %s shared', id, err))
+  c.shared = shared
+  c.store.setShared(shared)
+  return c
+}
+
+function getPersisterOptions (keys, opts) {
+  return Object.assign({}, {
+    ipns: {
+      key: keys.write
+    },
+    ipfs: ipfsOptions,
+    persistenceHeuristicOptions: {
+      maxDeltas: 3
+    },
+    decryptAndVerify: (data) => sharedCrypto.decryptAndVerify(keys, data),
+    signAndEncrypt: (data) => sharedCrypto.signAndEncrypt(keys, data)
+  }, opts)
+}
+
+let ipfsRepo
+const createIpfs = async () => {
+  // Naming and persistence are already supplied, so we don't need ipfs
+  if (suiteOptions.naming && suiteOptions.persistence) {
+    return {
+      stop: () => {}
+    }
+  }
+
+  // Repo must be shared for IPNS to work
+  ipfsRepo = ipfsRepo || createTempRepo()
+
+  const sharedIpfs = new IPFS(Object.assign({}, ipfsOptions, { repo: ipfsRepo }))
+  sharedIpfs.on('error', console.error)
+  await new Promise(resolve => sharedIpfs.isOnline() ? resolve() : sharedIpfs.once('ready', resolve))
+  return sharedIpfs
+}
+
+async function getStateValue (state) {
+  const tmp = await createCollab('tmp' + Math.random())
+  await tmp.store.saveDelta([null, null, state])
+  return tmp.shared.value()
+}
+
+function addDeltasAndAwaitPropagation (collab, persister, values) {
+  return new Promise(resolve => {
+    // Wait for all the deltas to be processed
+    const onBranchDeltaCount = (count, cid) => {
+      if (count >= values.length) {
+        persister.removeListener('branch delta count', onBranchDeltaCount)
+
+        // Wait for the HEAD to be updated with the last delta
+        const onPublish = (pubCid) => {
+          if (pubCid.equals(cid)) {
+            resolve()
+            persister.removeListener('publish', onPublish)
+          }
+        }
+        persister.on('publish', onPublish)
+      }
+    }
+    persister.on('branch delta count', onBranchDeltaCount)
+
+    // Sequentially add values, waiting for each to create a separate delta
+    let i = 0
+    const onDelta = () => {
+      if (i < values.length) {
+        collab.shared.add(values[i])
+        i++
+      } else {
+        collab.store.removeListener('delta', onDelta)
+      }
+    }
+    collab.store.on('delta', onDelta)
+    onDelta()
+  })
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error(err)
+})


### PR DESCRIPTION
An implementation of a persistence service as discussed in https://github.com/ipfs-shipyard/peer-star-app/issues/57

Stores a linked list in IPFS and a pointer to the head of the list in IPNS
```
snapshot <- delta <- delta <- delta
                                ^
                               HEAD
```

New deltas are added as they come in to the store and snapshots are taken after a certain interval or after a certain number of deltas.

#### TODO:
- [ ] implement shared persistence
  - [x] store snapshots/deltas to IPFS
  - [x] share HEAD state with IPNS
  IPNS does not yet use the DHT, so the above only works if the IPFS Repo is shared.
  Therefore we may need to
  - [ ] implement alternative naming system

- [ ] implement master election
  IPNS is single-write, so we need to implement a protocol to
  - elect a master replica
  - failover to a new replica if the master goes down

- [ ] more tests
  - [ ] persistence heuristic
  - [ ] various init / failover scenarios
