### PR TITLE
fix: pinner: correcly accounts for collaboration timeout for removal

### DIFF
--- a/src/pinner/index.js
+++ b/src/pinner/index.js
@@ -144,7 +144,7 @@ class AppPinner extends EventEmitter {
       if (activityTimeout) {
         clearTimeout(activityTimeout)
       }
-      setTimeout(onInnactivityTimeout, this._options.collaborationInnactivityTimeoutMS)
+      activityTimeout = setTimeout(onInnactivityTimeout, this._options.collaborationInnactivityTimeoutMS)
     }
 
     const onStateChanged = () => {


### PR DESCRIPTION
Should fix #177 as a side effect.