### PR TITLE
fix: set metrics every 5 seconds

### DIFF
--- a/src/pinner/pinner-metrics.js
+++ b/src/pinner/pinner-metrics.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// How often to update the metrics
+const REFRESH_INTERVAL = 5000
+
 module.exports = (pinner) => {
   const client = require('prom-client')
   const register = client.register
@@ -10,21 +13,17 @@ module.exports = (pinner) => {
     totalCollaborations: new client.Gauge({ name: 'peerstar_collaborations', help: 'total number of active collaborations' })
   }
 
-  pinner.on('collaboration started', () => {
-    metrics.totalCollaborations.inc(1)
-  })
+  setInterval(() => {
+    const numberOfCollabs = pinner._collaborations.size
+    metrics.totalCollaborations.set(numberOfCollabs)
+    pinner.ipfs.swarm.peers((err, peers) => {
+      if (err) {
+        throw err
+      }
+      metrics.totalConnectedPeers.set(peers.length)
+    })
+  }, REFRESH_INTERVAL)
 
-  pinner.on('collaboration stopped', () => {
-    metrics.totalCollaborations.dec(1)
-  })
-
-  const connMan = pinner.getGlobalConnectionManager()
-  connMan.on('connected', () => {
-    metrics.totalConnectedPeers.inc(1)
-  })
-  connMan.on('disconnected', () => {
-    metrics.totalConnectedPeers.dec(1)
-  })
   // const dialsSuccessTotal = new client.Counter({ name: 'rendezvous_dials_total_success', help: 'sucessfully completed dials since server started' })
   // const dialsFailureTotal = new client.Counter({ name: 'rendezvous_dials_total_failure', help: 'failed dials since server started' })
   // const dialsTotal = new client.Counter({ name: 'rendezvous_dials_total', help: 'all dials since server started' })


### PR DESCRIPTION
Instead of inc/dec a counter, we grab the values and set them once every
REFRESH_INTERVAL ms, defaults to 5000.

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>