### PR TITLE
Fix: pinner: makes the state coherent with the vector clock

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "datastore-level": "~0.10.0",
     "debug": "^4.1.0",
     "delay": "^4.1.0",
-    "delta-crdts": "~0.7.0",
+    "delta-crdts": "~0.7.1",
     "delta-crdts-msgpack-codec": "~0.2.0",
     "frequency-counter": "^1.0.1",
     "interface-datastore": "~0.6.0",

--- a/src/collaboration/clocks.js
+++ b/src/collaboration/clocks.js
@@ -5,20 +5,25 @@ const EventEmitter = require('events')
 const vectorclock = require('../common/vectorclock')
 
 module.exports = class Clocks extends EventEmitter {
-  constructor (id) {
+  constructor (id, options) {
     super()
     this._id = id
     this._clocks = new Map()
+    this._replicateOnly = options.replicateOnly
   }
 
-  setFor (peerId, clock, authoritative, isPinner) {
-    const previousClock = this.getFor(peerId)
-    const newClock = vectorclock.merge(previousClock, clock)
+  setFor (peerId, _clock, authoritative, isPinner) {
+    let clock = _clock
+    if (!this._replicateOnly) {
+      const previousClock = this.getFor(peerId)
+      clock = vectorclock.merge(previousClock, clock)
+    }
     // console.log(`${this._id}: %j => %j`, previousClock, newClock)
-    debug('%s: setting clock for %s: %j', this._id, peerId, newClock)
-    this._clocks.set(peerId, newClock)
-    this.emit('update', peerId, newClock, authoritative, isPinner)
-    return newClock
+    debug('%s: setting clock for %s: %j', this._id, peerId, clock)
+    console.log(`${this._id}: setting clock for ${peerId}: ${JSON.stringify(clock)}`)
+    this._clocks.set(peerId, clock)
+    this.emit('update', peerId, clock, authoritative, isPinner)
+    return clock
   }
 
   getFor (peerId) {

--- a/src/collaboration/clocks.js
+++ b/src/collaboration/clocks.js
@@ -9,7 +9,7 @@ module.exports = class Clocks extends EventEmitter {
     super()
     this._id = id
     this._clocks = new Map()
-    this._replicateOnly = options.replicateOnly
+    this._replicateOnly = options && options.replicateOnly
   }
 
   setFor (peerId, _clock, authoritative, isPinner) {

--- a/src/collaboration/clocks.js
+++ b/src/collaboration/clocks.js
@@ -20,7 +20,6 @@ module.exports = class Clocks extends EventEmitter {
     }
     // console.log(`${this._id}: %j => %j`, previousClock, newClock)
     debug('%s: setting clock for %s: %j', this._id, peerId, clock)
-    console.log(`${this._id}: setting clock for ${peerId}: ${JSON.stringify(clock)}`)
     this._clocks.set(peerId, clock)
     this.emit('update', peerId, clock, authoritative, isPinner)
     return clock

--- a/src/collaboration/index.js
+++ b/src/collaboration/index.js
@@ -48,7 +48,7 @@ class Collaboration extends EventEmitter {
     this._options = Object.assign({}, defaultOptions, options)
     this._parentCollab = parentCollab
     this._gossips = new Set()
-    this._clocks = this._options.clocks || new Clocks(selfId)
+    this._clocks = this._options.clocks || new Clocks(selfId, options)
     this.replication = Replication(selfId, this._clocks)
 
     if (!this._options.keys) {
@@ -304,10 +304,6 @@ class Collaboration extends EventEmitter {
 
   deliverRemoteMembership (membership) {
     return this._membership.deliverRemoteMembership(membership)
-  }
-
-  _storeName () {
-    return this._isRoot ? null : this.name
   }
 }
 

--- a/src/collaboration/pull-protocol.js
+++ b/src/collaboration/pull-protocol.js
@@ -27,6 +27,7 @@ module.exports = class PullProtocol {
     let ended = false
     let waitingForClock = null
     let timeout
+    let isPinner
 
     const onNewLocalClock = (clock) => {
       debug('%s got new clock from state:', this._peerId(), clock)
@@ -40,7 +41,15 @@ module.exports = class PullProtocol {
       debug('%s got new data from %s :', this._peerId(), remotePeerId, data)
 
       queue.add(async () => {
-        const [deltaRecord, newStates] = data
+        const [deltaRecord, newStates, peerInfo] = data
+
+        if (peerInfo && peerInfo.isPinner && !isPinner) {
+          isPinner = true
+          console.log('remote is pinner. please dont send data..')
+          output.push(encode([null, true]))
+          return
+        }
+
         let clock
         let states
         let delta
@@ -75,7 +84,8 @@ module.exports = class PullProtocol {
               if (!rootState) {
                 throw new Error('expected root state')
               }
-              const saved = await this._shared.apply(await this._decryptAndVerifyDelta(rootState), false)
+              const decryptedRootState = await this._decryptAndVerifyDelta(rootState)
+              const saved = await this._shared.apply(decryptedRootState, false)
               if (saved) {
                 for (let [collabName, collabState] of states) {
                   if (collabName === null) {
@@ -83,6 +93,8 @@ module.exports = class PullProtocol {
                   }
                   await this._shared.apply(await this._decryptAndVerifyDelta(collabState), false, true)
                 }
+              } else {
+                output.push(encode([null, true]))
               }
             } else if (delta) {
               debug('%s: saving delta', this._peerId(), deltaRecord)

--- a/src/collaboration/pull-protocol.js
+++ b/src/collaboration/pull-protocol.js
@@ -45,7 +45,6 @@ module.exports = class PullProtocol {
 
         if (peerInfo && peerInfo.isPinner && !isPinner) {
           isPinner = true
-          console.log('remote is pinner. please dont send data..')
           output.push(encode([null, true]))
           return
         }

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -201,7 +201,7 @@ module.exports = class PushProtocol {
     const input = pull.drain(handlingData(onMessage), onEnd)
     const output = pushable()
 
-    output.push(encode([null, null, { isPinner: this._options.replicateOnly}]))
+    output.push(encode([null, null, { isPinner: this._options.replicateOnly }]))
 
     return { sink: input, source: output }
   }

--- a/src/collaboration/push-protocol.js
+++ b/src/collaboration/push-protocol.js
@@ -44,14 +44,6 @@ module.exports = class PushProtocol {
       return clockDiff
     }
 
-    // const pushDeltaBatch = async (peerClock) => {
-    //   const batch = this._shared.deltaBatch(peerClock)
-    //   let [clock, authorClock, [, , batchState]] = batch
-    //   const batchClock = vectorclock.sumAll(clock, authorClock)
-    //   output.push(encode([await this._signAndEncryptDelta(batch)]))
-    //   return vectorclock.merge(peerClock, batchClock)
-    // }
-
     const pushDeltas = async (peerClock) => {
       const ds = this._shared.deltas(peerClock)
       let newRemoteClock = {}
@@ -83,7 +75,6 @@ module.exports = class PushProtocol {
         // Let's try to see if we have deltas to deliver
         if (!isPinner && !this._options.replicateOnly) {
           remoteClock = await pushDeltas(remoteClock)
-          // remoteClock = await pushDeltaBatch(remoteClock)
         }
 
         if (isPinner || remoteNeedsUpdate(myClock, remoteClock)) {
@@ -209,6 +200,8 @@ module.exports = class PushProtocol {
     }
     const input = pull.drain(handlingData(onMessage), onEnd)
     const output = pushable()
+
+    output.push(encode([null, null, { isPinner: this._options.replicateOnly}]))
 
     return { sink: input, source: output }
   }


### PR DESCRIPTION
Pinner was saving states with vector clocks, but since states may diverge between replicas and as the pinner is not able to merge states, the vector clocks cannot be merged.

This makes the state coherent with the vector clock on the pinner.